### PR TITLE
Fix unbound variable

### DIFF
--- a/docker-volume-snapshot
+++ b/docker-volume-snapshot
@@ -1,5 +1,5 @@
 #!/bin/bash
-set -eu -o pipefail
+set -e -o pipefail
 
 programname=`basename "$0"`
 


### PR DESCRIPTION
Got this error when attempting to run the script:

```
$ wget https://raw.githubusercontent.com/junedkhatri31/docker-volume-snapshot/main/docker-volume-snapshot
$ chmod +x docker-volume-snapshot
$ ./docker-volume-snapshot
```

> ./docker-volume-snapshot: line 18: $1: unbound variable

Removing `-u` fixes the issue. FYI:

```
$ bash --version
```

> GNU bash, version 5.1.16(1)-release (x86_64-pc-linux-gnu)
> Copyright (C) 2020 Free Software Foundation, Inc.
> License GPLv3+: GNU GPL version 3 or later <http://gnu.org/licenses/gpl.html>
> 
> This is free software; you are free to change and redistribute it.
> There is NO WARRANTY, to the extent permitted by law.
